### PR TITLE
add temperature data to LightDB Stream

### DIFF
--- a/01_IOT/CMakeLists.txt
+++ b/01_IOT/CMakeLists.txt
@@ -11,5 +11,6 @@ target_include_directories(app PUBLIC ${ZEPHYR_BASE}/subsys/net/ip)
 
 target_sources(app PRIVATE
 	src/main.c
+	src/tem_sensor.c
 	src/wifi_util.c
 )

--- a/01_IOT/src/tem_sensor.c
+++ b/01_IOT/src/tem_sensor.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/random/rand32.h>
+
+#define TEM_GEN_DELAY_S 1
+#define TEM_MIN 20
+#define TEM_MAX 38
+#define DELTA_LIMIT_HUNDREDTHS 50
+
+static struct sensor_value _temperature = { .val1 = 27, .val2 = 340000 };
+
+K_MUTEX_DEFINE(temperature_mutex);
+
+static int32_t get_tem_large(struct sensor_value *s)
+{
+	return (s->val1 * 1000000) + s->val2;
+}
+
+static void set_sensor_value(int32_t tem_large, struct sensor_value *s)
+{
+	s->val1 = tem_large / 1000000;
+	s->val2 = tem_large % 1000000;
+}
+
+static void update_temperature(struct sensor_value *tem)
+{
+	int32_t min = TEM_MIN * 1000000;
+	int32_t max = TEM_MAX * 1000000;
+
+	int32_t delta = (sys_rand32_get() % (DELTA_LIMIT_HUNDREDTHS + 1)) - (DELTA_LIMIT_HUNDREDTHS / 2);
+	int32_t tem_large = get_tem_large(tem) + (delta * 10000);
+
+	if (tem_large < min) {
+		tem_large = min;
+	} else if (tem_large > max) {
+		tem_large = max;
+	}
+
+	k_mutex_lock(&temperature_mutex, K_FOREVER);
+	set_sensor_value(tem_large, tem);
+	k_mutex_unlock(&temperature_mutex);
+}
+
+static void generate_temperature(void)
+{
+	while (1) {
+		update_temperature(&_temperature);
+		k_sleep(K_SECONDS(TEM_GEN_DELAY_S));
+	}
+}
+K_THREAD_DEFINE(temperature_thread_id, 1024, generate_temperature, NULL, NULL,
+		NULL, 5, 0, 0);
+
+void get_temperature(struct sensor_value *tem)
+{
+	if (k_mutex_lock(&temperature_mutex, K_MSEC(5)) == 0) {
+		tem->val1 = _temperature.val1;
+		tem->val2 = _temperature.val2;
+		k_mutex_unlock(&temperature_mutex);
+	}
+}

--- a/01_IOT/src/tem_sensor.h
+++ b/01_IOT/src/tem_sensor.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TEM_SENSOR_H__
+#define __TEM_SENSOR_H__
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Get simulated temperature sensor data
+ *
+ * Temperature is generated with two decimal places of precision to simulate the
+ * type of readings that would be received from a BME280 sensor.
+ *
+ * @param tem sensor_value point to store the new temperature values. val1 is
+ * the integral part, val2 is the decimal part and returns six digits of
+ * precision to adhere to the Zephyr sensor API.
+ */
+void get_temperature(struct sensor_value *tem);
+
+#endif


### PR DESCRIPTION
This commit implements simulated temperature data. New readings are generated once per second using random values that are restricted to a small delta. The `get_temperature(struct sensor_valeue *)` function may be called as often as needed to retrieve the most recent reading.