### PR TITLE
Increase network buffer sizes to fix buffer allocation failures

### DIFF
--- a/01_IOT/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/01_IOT/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -38,8 +38,8 @@ CONFIG_NET_PKT_TX_COUNT=8
 
 # Below section is the primary contributor to SRAM and is currently
 # tuned for performance, but this will be revisited in the future.
-CONFIG_NET_BUF_RX_COUNT=16
-CONFIG_NET_BUF_TX_COUNT=16
+CONFIG_NET_BUF_RX_COUNT=32
+CONFIG_NET_BUF_TX_COUNT=32
 CONFIG_NET_BUF_DATA_SIZE=128
 CONFIG_HEAP_MEM_POOL_SIZE=153600
 CONFIG_NET_TC_TX_COUNT=0

--- a/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -38,8 +38,8 @@ CONFIG_NET_PKT_TX_COUNT=8
 
 # Below section is the primary contributor to SRAM and is currently
 # tuned for performance, but this will be revisited in the future.
-CONFIG_NET_BUF_RX_COUNT=16
-CONFIG_NET_BUF_TX_COUNT=16
+CONFIG_NET_BUF_RX_COUNT=32
+CONFIG_NET_BUF_TX_COUNT=32
 CONFIG_NET_BUF_DATA_SIZE=128
 CONFIG_HEAP_MEM_POOL_SIZE=153600
 CONFIG_NET_TC_TX_COUNT=0


### PR DESCRIPTION
I haven't extensively tested this, but this looks like it fixes the errors like the following:

```
[00:00:09.514,617] <err> net_buf: pkt_alloc_buffer():876: Failed to get free buffer
[00:00:09.514,648] <err> net_pkt: Data buffer (704) allocation failed.
[00:00:09.614,044] <err> net_buf: pkt_alloc_buffer():876: Failed to get free buffer
[00:00:09.614,074] <err> net_pkt: Data buffer (670) allocation failed.
[00:00:09.614,074] <wrn> net_conn: pkt cloning failed, pkt 0x20038c58 dropped
[00:00:10.737,854] <err> net_buf: pkt_alloc_buffer():876: Failed to get free buffer
[00:00:10.737,884] <err> net_pkt: Data buffer (742) allocation failed.
[00:00:10.737,884] <wrn> net_conn: pkt cloning failed, pkt 0x20038c58 dropped
```

For more info, see https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf70/developing/constrained.html#networking-stack

