### PR TITLE
App should only select one WPA authentication type at at time

### DIFF
--- a/01_IOT/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/01_IOT/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -16,10 +16,10 @@ CONFIG_WPA_SUPP=y
 
 # These should be in a board file for the nRF7002:
 # (Choose only one that applies or none for no WiFi password)
+# CONFIG_STA_KEY_MGMT_NONE=y
 CONFIG_STA_KEY_MGMT_WPA2=y
-CONFIG_STA_KEY_MGMT_WPA2=n
-CONFIG_STA_KEY_MGMT_WPA2_256=n
-CONFIG_STA_KEY_MGMT_WPA3=n
+# CONFIG_STA_KEY_MGMT_WPA2_256=y
+# CONFIG_STA_KEY_MGMT_WPA3=y
 
 # System settings
 CONFIG_NEWLIB_LIBC=y

--- a/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -16,10 +16,10 @@ CONFIG_WPA_SUPP=y
 
 # These should be in a board file for the nRF7002:
 # (Choose only one that applies or none for no WiFi password)
+# CONFIG_STA_KEY_MGMT_NONE=y
 CONFIG_STA_KEY_MGMT_WPA2=y
-CONFIG_STA_KEY_MGMT_WPA2=n
-CONFIG_STA_KEY_MGMT_WPA2_256=n
-CONFIG_STA_KEY_MGMT_WPA3=n
+# CONFIG_STA_KEY_MGMT_WPA2_256=y
+# CONFIG_STA_KEY_MGMT_WPA3=y
 
 # System settings
 CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
Fixes `CONFIG_STA_KEY_MGMT_WPA2` being set to `=y` and `=n`.