### PR TITLE
Add initial support for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,10 @@
     "vscode": {
       "settings": {
         "cmake.configureOnOpen": false,
+        "cmake.showOptionsMovedNotification": false,
         "C_Cpp.default.compilerPath": "/opt/toolchains/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
-        "C_Cpp.default.compileCommands": "/workspace/app/build/compile_commands.json"
+        "C_Cpp.default.compileCommands": "/workspace/app/build/compile_commands.json",
+        "git.autofetch": false
       },
       "extensions": [
         "ms-vscode.cpptools-extension-pack",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,15 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/app,type=bind",
   "workspaceFolder": "/workspace",
   "onCreateCommand": "west init -l app/ && west update && west zephyr-export && pip install -r deps/zephyr/scripts/requirements.txt",
-  "remoteEnv": { "LC_ALL": "C" }
+  "remoteEnv": { "LC_ALL": "C" },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ms-vscode.cpptools-extension-pack",
+        "nordic-semiconductor.nrf-devicetree",
+        "nordic-semiconductor.nrf-kconfig"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "golioth/golioth-zephyr-base:0.16.3-SDK-v0",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/app,type=bind",
+  "workspaceFolder": "/workspace",
+  "onCreateCommand": "west init -l app/ && west update --narrow -o=--depth=1 && west zephyr-export && pip install -r deps/zephyr/scripts/requirements.txt"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
   "image": "golioth/golioth-zephyr-base:0.16.3-SDK-v0",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/app,type=bind",
   "workspaceFolder": "/workspace",
-  "onCreateCommand": "west init -l app/ && west update --narrow -o=--depth=1 && west zephyr-export && pip install -r deps/zephyr/scripts/requirements.txt"
+  "onCreateCommand": "west init -l app/ && west update && west zephyr-export && pip install -r deps/zephyr/scripts/requirements.txt",
+  "remoteEnv": { "LC_ALL": "C" }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,11 @@
   "remoteEnv": { "LC_ALL": "C" },
   "customizations": {
     "vscode": {
-      "settings": {},
+      "settings": {
+        "cmake.configureOnOpen": false,
+        "C_Cpp.default.compilerPath": "/opt/toolchains/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
+        "C_Cpp.default.compileCommands": "/workspace/app/build/compile_commands.json"
+      },
       "extensions": [
         "ms-vscode.cpptools-extension-pack",
         "nordic-semiconductor.nrf-devicetree",


### PR DESCRIPTION
This PR adds initial support for working in Codespaces using a devcontainer

* Uses Golioth base image for compiler tools
* Installs and updates west
* Configures env variables so menuconfig  works
* Adds common VScode exctensions (C/C++, CMake, Devicetree, Kconfig) 