### PR TITLE
west: update west download for new directory

### DIFF
--- a/utility/west-commands/west_download.py
+++ b/utility/west-commands/west_download.py
@@ -9,7 +9,7 @@ from west import log                   # use this for user output
 
 import os, time, shutil
 
-DEFAULT_DOWNLOAD_DIR = '/workspace/Downloads'
+DEFAULT_DOWNLOAD_DIR = '/zephyr-training/Downloads'
 
 class Download(WestCommand):
 


### PR DESCRIPTION
The Codespaces working directory was moved from /workspace to /zephyr-training. This commit updates that change in the custom west download command.