### PR TITLE
nrf7002: increase net buffer

### DIFF
--- a/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/05_golioth/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -39,8 +39,8 @@ CONFIG_NET_PKT_TX_COUNT=8
 
 # Below section is the primary contributor to SRAM and is currently
 # tuned for performance, but this will be revisited in the future.
-CONFIG_NET_BUF_RX_COUNT=16
-CONFIG_NET_BUF_TX_COUNT=16
+CONFIG_NET_BUF_RX_COUNT=32
+CONFIG_NET_BUF_TX_COUNT=32
 CONFIG_NET_BUF_DATA_SIZE=128
 CONFIG_HEAP_MEM_POOL_SIZE=153600
 CONFIG_NET_TC_TX_COUNT=1


### PR DESCRIPTION
Increase net buffers on the nRF7002 to match what we're using on 01_IOT