### PR TITLE
workflows: add HEX_FILE input for name of compiled binary

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -7,18 +7,27 @@ on:
   workflow_dispatch:
     inputs:
       ZEPHYR_SDK:
+        description: Zephyr toolchain version
         required: true
         type: string
         default: 0.16.3
       BOARD:
+        description: Zephyr board to build
         required: true
         type: string
         default: nrf9160dk/nr9160/ns
       ARTIFACT:
+        description: Whether or not to save the artifact produced by the build
         required: true
         type: boolean
         default: false
+      HEX_FILE:
+        description: Name of the hex file to save
+        required: false
+        type: string
+        default: merged.hex
       TAG:
+        description: version number of the firmware build
         type: string
 
   workflow_call:
@@ -32,6 +41,9 @@ on:
       ARTIFACT:
         required: true
         type: boolean
+      HEX_FILE:
+        required: true
+        type: string
       TAG:
         type: string
 
@@ -78,7 +90,7 @@ jobs:
         run: |
           cd build
           mkdir -p artifacts
-          mv zephyr/merged.hex ./artifacts/Golioth_${{ steps.nicename.outputs.BOARD_NICENAME }}_kitchen_sink_${{ inputs.TAG }}.hex
+          mv zephyr/${{ inputs.HEX_FILE }} ./artifacts/Golioth_${{ steps.nicename.outputs.BOARD_NICENAME }}_kitchen_sink_${{ inputs.TAG }}.hex
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,20 @@ jobs:
     build-binaries:
         strategy:
             matrix:
-              ZEPHYR_SDK: [0.16.3]
-              BOARD: ["nrf9160dk/nrf9160/ns","nrf7002dk/nrf5340/cpuapp"]
+              include:
+                - BOARD: nrf9160dk/nrf9160/ns
+                  ZEPHYR_SDK: 0.16.3
+                  HEX_FILE: merged.hex
+                - BOARD: nrf7002dk/nrf5340/cpuapp
+                  ZEPHYR_SDK: 0.16.3
+                  HEX_FILE: zephyr.hex
 
         uses: ./.github/workflows/build_zephyr.yml
         with:
           ZEPHYR_SDK: ${{ matrix.ZEPHYR_SDK }}
           BOARD: ${{ matrix.BOARD }}
           ARTIFACT: true
+          HEX_FILE: ${{ matrix.HEX_FILE }}
           TAG: ${{ inputs.version }}
 
     upload-binaries:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,11 @@ jobs:
       ZEPHYR_SDK: 0.16.3
       BOARD: nrf9160dk/nrf9160/ns
       ARTIFACT: false
+      HEX_FILE: merged.hex
   test_build_nrf7002:
     uses: ./.github/workflows/build_zephyr.yml
     with:
       ZEPHYR_SDK: 0.16.3
       BOARD: nrf7002dk/nrf5340/cpuapp
       ARTIFACT: false
+      HEX_FILE: zephyr.hex


### PR DESCRIPTION
The binary file name produced by the build step is different for the nrf9160 and the nrf7002. Add an input that specifies this filename.