### PR TITLE
Szczys/update devcontainer golioth 0.22.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "golioth/golioth-zephyr-base:0.16.3-SDK-v0",
+  "image": "golioth/golioth-zephyr-base:0.17.4-SDK-v0",
   "workspaceMount": "source=${localWorkspaceFolder},target=/zephyr-training/app,type=bind",
   "workspaceFolder": "/zephyr-training",
   "onCreateCommand": "bash -i /zephyr-training/app/.devcontainer/onCreateCommand.sh",
@@ -9,7 +9,7 @@
       "settings": {
         "cmake.configureOnOpen": false,
         "cmake.showOptionsMovedNotification": false,
-        "C_Cpp.default.compilerPath": "/opt/toolchains/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
+        "C_Cpp.default.compilerPath": "/opt/toolchains/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
         "C_Cpp.default.compileCommands": "/zephyr-training/app/build/compile_commands.json",
         "git.autofetch": false
       },

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -3,7 +3,8 @@
 west init -l app
 west update
 west zephyr-export
-pip install -r deps/zephyr/scripts/requirements.txt
+west patch apply
+uv pip install -r deps/zephyr/scripts/requirements.txt
 echo "alias ll='ls -lah'" >> $HOME/.bashrc
 west completion bash > $HOME/west-completion.bash
 echo 'source $HOME/west-completion.bash' >> $HOME/.bashrc

--- a/utility/west-commands/west_download.py
+++ b/utility/west-commands/west_download.py
@@ -48,8 +48,8 @@ class Download(WestCommand):
         with open(os.path.join(build_dir, 'CMakeCache.txt')) as f:
             cmake_lines = f.readlines()
         for line in cmake_lines:
-            if line.startswith("APPLICATION_SOURCE_DIR:PATH="):
-                app_path = line.split("APPLICATION_SOURCE_DIR:PATH=")[1]
+            if line.startswith("APP_DIR:PATH="):
+                app_path = line.split("APP_DIR:PATH=")[1]
                 return_vals["cmake_src_dir"] = os.path.basename(app_path).strip()
             elif line.startswith("BOARD:STRING="):
                 board_string = line.split("BOARD:STRING=")[1].strip()
@@ -83,9 +83,7 @@ class Download(WestCommand):
         cmake_vals = self.get_cmake_values(build_dir)
         board_name = cmake_vals["board_name"]
 
-        if board_name == "nrf7002dk/nrf5340/cpuapp":
-            bin_name = 'zephyr.hex'
-        elif board_name == "nrf9160dk/nrf9160/ns":
+        if board_name == "nrf7002dk/nrf5340/cpuapp" or board_name == "nrf9160dk/nrf9160/ns":
             bin_name = 'merged.hex'
         else:
             log.die("Don't know which binary to move for this board:", board_name)


### PR DESCRIPTION
- Update devcontainer build with Zephyr SDK 0.17.4, uv pip install, and west patch apply
- Update `west download` command for change binary file names and to use APP_DIR for app name 

Resolves: https://github.com/golioth/firmware-issue-tracker/issues/1012